### PR TITLE
Fix: False positive in deck application

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,6 @@
 ---
 on: [push, pull_request]
+name: Integration tests
 
 jobs:
   integration-tests:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OWASP ModSecurity Core Rule Set - Nextcloud Rule Exclusions Plugin
 
+![Integration tests](https://github.com/coreruleset/nextcloud-rule-exclusions-plugin/actions/workflows/integration.yml/badge.svg)
+
 ## Description
 
 This plugin contains rule exclusions for [Nextcloud](https://nextcloud.com/), a productivity platform and file hosting service. These rule exclusions are designed to resolve common false positives and allow for easier integration with the OWASP ModSecurity Core Rule Set (CRS).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# OWASP ModSecurity Core Rule Set - Nextcloud Rule Exclusions Plugin
+# OWASP CRS - Nextcloud Rule Exclusions Plugin
 
 ![Integration tests](https://github.com/coreruleset/nextcloud-rule-exclusions-plugin/actions/workflows/integration.yml/badge.svg)
 
 ## Description
 
-This plugin contains rule exclusions for [Nextcloud](https://nextcloud.com/), a productivity platform and file hosting service. These rule exclusions are designed to resolve common false positives and allow for easier integration with the OWASP ModSecurity Core Rule Set (CRS).
+This plugin contains rule exclusions for [Nextcloud](https://nextcloud.com/), a productivity platform and file hosting service. These rule exclusions are designed to resolve common false positives and allow for easier integration with the OWASP CRS (CRS).
 
 ## Installation
 
@@ -81,6 +81,6 @@ After the plugin is enabled, Nextcloud should work without problems caused by CR
 
 ## License
 
-Copyright (c) 2022-2024 OWASP ModSecurity Core Rule Set project. All rights reserved.
+Copyright (c) 2022-2024 OWASP CRS project. All rights reserved.
 
-The OWASP ModSecurity Core Rule Set and its official plugins are distributed under Apache Software License (ASL) version 2. Please see the enclosed LICENSE file for full details.
+The OWASP CRS and its official plugins are distributed under Apache Software License (ASL) version 2. Please see the enclosed LICENSE file for full details.

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1338,6 +1338,21 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/user_status/api/v[0-9]+/use
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
 
 #
+# [ Nextcloud Deck ]
+#
+
+# Moving a card in Deck app
+SecRule REQUEST_FILENAME "@rx /apps/deck/cards/[0-9]+/reorder$" \
+    "id:9508810,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
+
+#
 # [ Users ]
 #
 
@@ -1915,18 +1930,3 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/outbox/(?:from-draft/)?[0-9]+$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.editorBody,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.subject"
-
-#
-# [ Nextcloud Deck ]
-#
-
-# Moving a card in Deck app
-SecRule REQUEST_FILENAME "@rx /apps/deck/cards/[0-9]+/reorder$" \
-    "id:9508993,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1916,8 +1916,12 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/outbox/(?:from-draft/)?[0-9]+$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.editorBody,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.subject"
 
-# Moving a card in Deck application
-SecRule REQUEST_FILENAME "@rx /apps/deck/cards/[0-9]+/reorder?$" \
+#
+# [ Nextcloud Deck ]
+#
+
+# Moving a card in Deck app
+SecRule REQUEST_FILENAME "@rx /apps/deck/cards/[0-9]+/reorder$" \
     "id:9508993,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1,8 +1,8 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set Plugin
+# OWASP CRS Plugin
 # Copyright (c) 2021-2024 Core Rule Set project. All rights reserved.
 #
-# The OWASP ModSecurity Core Rule Set plugins are distributed under
+# The OWASP CRS plugins are distributed under
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1915,3 +1915,14 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/outbox/(?:from-draft/)?[0-9]+$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.editorBody,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.subject"
+
+# Moving a card in Deck application
+SecRule REQUEST_FILENAME "@rx /apps/deck/cards/[0-9]+/reorder?$" \
+    "id:9508993,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"

--- a/plugins/nextcloud-rule-exclusions-config.conf
+++ b/plugins/nextcloud-rule-exclusions-config.conf
@@ -1,8 +1,8 @@
 # ------------------------------------------------------------------------
-# OWASP ModSecurity Core Rule Set Plugin
+# OWASP CRS Plugin
 # Copyright (c) 2021-2024 Core Rule Set project. All rights reserved.
 #
-# The OWASP ModSecurity Core Rule Set plugins are distributed under
+# The OWASP CRS plugins are distributed under
 # Apache Software License (ASL) version 2
 # Please see the enclosed LICENSE file for full details.
 # ------------------------------------------------------------------------

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508115.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508115.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80
@@ -31,7 +31,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80
@@ -50,7 +50,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80
@@ -68,7 +68,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80
@@ -86,7 +86,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80
@@ -104,7 +104,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80
@@ -122,7 +122,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508176.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508176.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               if: stuff
             port: 80

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508400.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508400.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -29,7 +29,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -45,7 +45,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -62,7 +62,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508401.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508401.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -29,7 +29,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -45,7 +45,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -61,7 +61,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508402.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508402.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -31,7 +31,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508403.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508403.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -29,7 +29,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -45,7 +45,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -61,7 +61,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508411.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508411.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -29,7 +29,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508420.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508420.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -29,7 +29,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -45,7 +45,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -61,7 +61,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -77,7 +77,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -93,7 +93,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -109,7 +109,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -125,7 +125,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -141,7 +141,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -157,7 +157,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -173,7 +173,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -189,7 +189,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -205,7 +205,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -221,7 +221,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -237,7 +237,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -253,7 +253,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -269,7 +269,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -285,7 +285,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -301,7 +301,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -317,7 +317,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -333,7 +333,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -349,7 +349,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -365,7 +365,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -381,7 +381,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -397,7 +397,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -413,7 +413,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -429,7 +429,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -445,7 +445,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -461,7 +461,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -477,7 +477,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -493,7 +493,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -509,7 +509,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508624.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508624.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -31,7 +31,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508628.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508628.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
@@ -28,7 +28,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
@@ -43,7 +43,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
@@ -59,7 +59,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508629.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508629.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508630.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508630.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
@@ -28,7 +28,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508631.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508631.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               data: "lastReqId=lsbusydifb08"
             port: 80
@@ -29,7 +29,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               data: "lastReqId=0x0800dasf86gm"
             port: 80

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508632.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508632.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508810.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508810.yaml
@@ -3,9 +3,9 @@ meta:
   author: "Jean-Kevin Kpadey"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508993.yaml
+  name: 9508810.yaml
 tests:
-  - test_title: 9508993-1
+  - test_title: 9508810-1
     desc: |
       Moving cards on Deck apps.
       Target: description
@@ -26,4 +26,4 @@ tests:
               Use this [link](https://github.com/microsoft/vscode/issues?page=3&q=is%3Aissue+is%3Aopen).
           output:
             no_log_contains: |
-              id "911100"|id "932200"|id "933210"|id "942200"|id "942260"|id "942370"|id "942430"|id "942440"|id "949110"|id "980130"
+              id "911100"|id "932200"|id "933210"|id "942200"|id "942260"|id "942370"|id "942430"|id "942440"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508850.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508850.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -28,7 +28,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -43,7 +43,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
@@ -58,7 +58,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508852.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508852.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508880.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508880.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508881.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508881.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -28,7 +28,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508978.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508978.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508991.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508991.yaml
@@ -17,7 +17,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -37,7 +37,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -57,7 +57,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -77,7 +77,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -97,7 +97,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -117,7 +117,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -137,7 +137,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -157,7 +157,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -176,7 +176,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -195,7 +195,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508992.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508992.yaml
@@ -16,7 +16,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -35,7 +35,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -53,7 +53,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -72,7 +72,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -91,7 +91,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
@@ -109,7 +109,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP ModSecurity Core Rule Set
+              User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508993.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508993.yaml
@@ -20,7 +20,10 @@ tests:
             port: 80
             method: PUT
             uri: /apps/deck/cards/1/reorder
-            data: "description=This is a description.\n\nUse this [link](https://github.com/microsoft/vscode/issues?page=3&q=is%3Aissue+is%3Aopen).\n"
+            data: |
+              description=This is a description.
+              
+              Use this [link](https://github.com/microsoft/vscode/issues?page=3&q=is%3Aissue+is%3Aopen).
           output:
             no_log_contains: |
-              id"911100"|id "93(?:[23]2[10]0)"|id "94(?:2[234][03467]0|9110)"|id "980130"
+              id "911100"|id "932200"|id "933210"|id "942200"|id "942260"|id "942370"|id "942430"|id "942440"|id "949110"|id "980130"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508993.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508993.yaml
@@ -22,7 +22,7 @@ tests:
             uri: /apps/deck/cards/1/reorder
             data: |
               description=This is a description.
-              
+
               Use this [link](https://github.com/microsoft/vscode/issues?page=3&q=is%3Aissue+is%3Aopen).
           output:
             no_log_contains: |

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508993.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508993.yaml
@@ -1,0 +1,26 @@
+---
+meta:
+  author: "Jean-Kevin Kpadey"
+  description: "Nextcloud Rule Exclusions Plugin"
+  enabled: true
+  name: 9508993.yaml
+tests:
+  - test_title: 9508993-1
+    desc: |
+      Moving cards on Deck apps.
+      Target: description
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: PUT
+            uri: /apps/deck/cards/1/reorder
+            data: "description=This is a description.\n\nUse this [link](https://github.com/microsoft/vscode/issues?page=3&q=is%3Aissue+is%3Aopen).\n"
+          output:
+            no_log_contains: |
+              id"911100"|id "93(?:[23]2[10]0)"|id "94(?:2[234][03467]0|9110)"|id "980130"


### PR DESCRIPTION
When moving a card,the PUT method is not allowed.
Content of arg "description" triggers multiple rules.